### PR TITLE
send_card no-op implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,20 @@ BACKEND = 'Discord'
 BOT_EXTRA_BACKEND_DIR = '/path_to/err-backend-discord'
 ```
 
-to your config.py
+to your `config.py`
 
 ## Authentication
 
-Create a bot user then you can directly use the token of the bot user.  
-For further information about getting a bot user into a server please see: https://discordapp.com/developers/docs/topics/oauth2
+Create an application, then a bot user and you can directly use the token of the bot user in your `config.py`:
 
 ```
 BOT_IDENTITY = {
     'token' : 'changeme'
 }
 ```
+
+For further information about getting a bot user into a server please see: https://discordapp.com/developers/docs/topics/oauth2. You can use [this tool](https://discordapi.com/permissions.html) to generate a proper invitation link.
+
 
 ## Contributing
 

--- a/discordb.py
+++ b/discordb.py
@@ -243,6 +243,9 @@ class DiscordBackend(ErrBot):
 
         super().send_message(msg)
 
+    def send_card(self, card):
+        self.debug('Discord backend does not render cards.')
+
     def build_reply(self, mess, text=None, private=False):
         response = self.build_message(text)
         if mess.is_direct:


### PR DESCRIPTION
For now, just log some message and don't display any card.

According to https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-?page=4, only a subset of Markdown is supported in Discord messages.

This PR also enhances the README a bit.