### PR TITLE
Rollback the automatic upgrade of discord.py to 1.6.0 back down to 1.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-discord.py==1.6.0
+discord.py==1.5.1


### PR DESCRIPTION
See https://github.com/gbin/err-backend-discord/issues/38 - version 1.6.0 of discord.py is buggy for this plugin and needs further investigation.