### PR TITLE
Support discord client v1.6.0 to fix #38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] 2021-01-14
+### Changed
+  - Use discord client 1.6.0
+  - Discord client uses Member intents.
+
 ## [1.0.1] 2019-11-23
 ### Changed
   - Use discord client 1.2.5
@@ -11,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0] 2019-10-18
 ### Added
   - Added changelog file.
+
 ### Changed
   - Use discord client 1.2.4
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Errbot - Discord
 
-This is a [Discord](http://discordapp.com) back-end for [Errbot](http://errbot.io).  It allows you to use errbot from Discord to execute commands.
+This is a [Discord](http://discordapp.com) back-end for [Errbot](http://errbot.io).  It allows you to use Errbot from Discord to execute commands.
 [![Updates](https://pyup.io/repos/github/gbin/err-backend-discord/shield.svg)](https://pyup.io/repos/github/gbin/err-backend-discord/)
 
 ## Installation
-An errbot instance is required to install the discord back-end.  See the errbot installation [documentation](http://errbot.io/en/latest/user_guide/setup.html#option-2-installing-errbot-in-a-virtualenv-preferred) for details.
+An Errbot instance is required to install the discord back-end.  See the Errbot installation [documentation](http://errbot.io/en/latest/user_guide/setup.html#option-2-installing-errbot-in-a-virtualenv-preferred) for details.
 
 ### Requirements
  * Python 3.6 or later
  * Discord.py 1.2.3 or later
 
 ### Virtual Environment
-The steps below are to install the discord back-end in errbot's virtual environment.  In the examples below, the virtual environment was set to `/opt/errbot/virtualenv` and errbot initialised in `/opt/errbot`.  The "extra" back-end directory is set to `/opt/errbot/backend`.
+The steps below are to install the discord back-end in Errbot's virtual environment.  In the examples below, the virtual environment was set to `/opt/errbot/virtualenv` and Errbot initialised in `/opt/errbot`.  The "extra" back-end directory is set to `/opt/errbot/backend`.
 
 
-1. If not already set, set errbot's `BOT_EXTRA_BACKEND_DIR` variable in `/opt/errbot/config.py` to the directory you will use to place additional back-ends.
+1. If not already set, set Errbot's `BOT_EXTRA_BACKEND_DIR` variable in `/opt/errbot/config.py` to the directory you will use to place additional back-ends.
 ```
 BOT_EXTRA_BACKEND_DIR=/opt/errbot/backend
 ```
@@ -22,12 +22,12 @@ BOT_EXTRA_BACKEND_DIR=/opt/errbot/backend
 ```
 BACKEND = 'Discord'
 ```
-3. Clone repository to your errbot back-end directory.
+3. Clone repository to your Errbot back-end directory.
 ```
 cd /opt/errbot/backend
 git clone https://github.com/gbin/err-backend-discord.git
 ```
-4. Install back-end dependencies (errbot's virtual environment must be activated to install the dependencies into it).
+4. Install back-end dependencies (Errbot's virtual environment must be activated to install the dependencies into it).
 ```
 source /opt/errbot/virtualenv/bin/activate
 cd err-backend-discord
@@ -40,6 +40,7 @@ BOT_IDENTITY = {
  'token' : 'changeme'
 }
 ```
+6. Enable *SERVER MEMBERS INTENT* for your bot on the Discord website.  See [here](https://discordpy.readthedocs.io/en/latest/intents.html?highlight=intents#privileged-intents) for the required steps.
 
 ## Create a discord application
 For further information about getting a bot user into a server please see: https://discordapp.com/developers/docs/topics/oauth2. You can use [this tool](https://discordapi.com/permissions.html) to generate a proper invitation link.

--- a/discordb.py
+++ b/discordb.py
@@ -574,6 +574,8 @@ class DiscordBackend(ErrBot):
             return DiscordCategory(room_name[2:], guild.id)
         elif room_name.startswith("#"):
             return DiscordRoom(room_name[1:], guild.id)
+        else:
+            return DiscordRoom(room_name, guild.id)
 
     def send_message(self, msg: Message):
         super().send_message(msg)

--- a/discordb.py
+++ b/discordb.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import List, Optional, Union
 
 from discord.utils import find
+
 from errbot.backends.base import (
     Person,
     Message,
@@ -459,7 +460,10 @@ class DiscordBackend(ErrBot):
             sys.exit(1)
         self.bot_identifier = None
 
-        DiscordBackend.client = discord.Client()
+        intents = discord.Intents.default()
+        intents.members = True
+        DiscordBackend.client = discord.Client(intents=intents)
+
         # Register discord event coroutines.
         for fn in [
             self.on_ready,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-discord.py==1.5.1
+discord.py==1.6.0


### PR DESCRIPTION
Errbot uses API calls to fetch user information that Discord considers as privileged.  To use these privileged API calls, member intents must be enabled.  This PR updates the README with instructions on how to configure intents on the Discord web site as well as adds the supporting code.