### PR TITLE
self.send() channel + guild support 🗨️ 

### DIFF
--- a/discordb.py
+++ b/discordb.py
@@ -693,12 +693,19 @@ class DiscordBackend(ErrBot):
 
         Valid forms of strreps:
         user#discriminator      -> Person
-
+        #channel@guild_id       -> Room
+        
         :param string_representation:
         :return: Identifier
+
+        Room Example: #general@12345678901234567 -> Sends a message to the #general channel of the guild with id 12345678901234567
         """
         if not string_representation:
             raise ValueError("Empty strrep")
+        
+        if string_representation.startswith('#'):
+            strrep_split = string_representation.split('@')
+            return DiscordRoom(strrep_split[0][1:], int(strrep_split[1]))
 
         if "#" in str(string_representation):
             user, discriminator = str(string_representation).split("#")


### PR DESCRIPTION
# `self.send()` channel + guild support

## What is this?

A pull request to enable `self.send()` to publish messages directly to a Discord channel with an associated `guild_id`

## Why is this?

Being able to send messages to a Discord channel with a corresponding `guild_id` is a feature myself and many other users can benefit from.

Since there are very frequent name clashes (ie. lots of channels with a `#general`) you need to associate the `guild_id` to prevent these clashes. This feature does exactly that and with ease.

## Example:

```python
self.send(
    self.build_identifier("#general@12345678901234567"),
    "hello world!"
)
```

Where `#general` is the channel and `@12345678901234567` is the Discord `guild_id` to send the message to. `"hello world!"` is the message that will be delivered!