### PR TITLE
Fix DiscordRoom with no ID

### DIFF
--- a/src/err-backend-discord/discordlib/room.py
+++ b/src/err-backend-discord/discordlib/room.py
@@ -31,7 +31,7 @@ class DiscordRoom(Room, DiscordSender):
         if channel is None:
             raise ValueError(f"Channel id:{channel_id} doesn't exist!")
 
-        return cls(channel.name, channel.guild.id)
+        return cls(channel.name, channel.guild.id, channel.id)
 
     def __init__(
         self, channel_name: str = None, guild_id: str = None, channel_id: str = None


### PR DESCRIPTION
This fix make the bot work when I issue !help on my discord server.

I started with version 4.0.0 from pip but had the same error ass issue #59

> ERROR    discord.client            Ignoring exception in on_ready
> Traceback (most recent call last):
>   File "/root/errbot-venv/lib/python3.10/site-packages/discord/client.py", line 409, in _run_event
>     await coro(*args, **kwargs)
>   File "/root/errbot-venv/lib/python3.10/site-packages/errbot/backends/err-backend-discord.py", line 90, in on_ready
>     self.bot_identifier = DiscordPerson(DiscordBackend.client.user.id)
>   File "/root/errbot-venv/lib/python3.10/site-packages/errbot/backends/discordlib/person.py", line 56, in __init__
>     raise ValueError(f"Invalid Discord user id {type(user_id)} {user_id}.")
> ValueError: Invalid Discord user id <class 'int'> XXXXXXXXXXXXXXXXXXX

Found @nzlosh reference and tried that branch.

Now error changed.

> ERROR    discord.client            Ignoring exception in on_message
> Traceback (most recent call last):
>   File "/root/errbot-venv/lib/python3.10/site-packages/discord/client.py", line 409, in _run_event
>     await coro(*args, **kwargs)
>   File "/root/errbot-venv/lib/python3.10/site-packages/errbot/backends/err-backend-discord.py", line 99, in on_message
>     if self.process_message(err_msg):
>   File "/root/errbot-venv/lib/python3.10/site-packages/errbot/core.py", line 270, in process_message
>     raise Exception(
> Exception: msg.frm not an Identifier as it misses the "person" property. Class of frm : <class 'discordlib.room.DiscordRoomOccupant'>.

I dont understand every pice of code and never worked with discord.py but looking at errors and putting some logs, I seemed to me that _channel_id was not set.

Added "channel.id" in the from_id class method and I worked.

I dont know if it breaks something else.

Just wanted to post this so others can validate and maybe explain why this works 😄 

> DEBUG    errbot.plugins.VersionChe Latest Errbot version is: 6.1.9
> DEBUG    errbot.plugins.VersionChe Installed Errbot version is: 6.1.9

![image](https://github.com/errbotio/err-backend-discord/assets/18060505/ac3508df-5547-4a58-9575-9fa086929e61)
