### PR TITLE
Do not react to bots

### DIFF
--- a/src/err-backend-discord/err-backend-discord.py
+++ b/src/err-backend-discord/err-backend-discord.py
@@ -89,6 +89,13 @@ class DiscordBackend(ErrBot):
         """
         err_msg = Message(msg.content, extras=msg.embeds)
 
+        # if the message coming in is from a webhook, it will not have a username
+        # this will cause the whole process to fail.  In those cases, return without
+        # processing.
+
+        if msg.author.bot:
+            return
+
         if isinstance(msg.channel, discord.abc.PrivateChannel):
             err_msg.frm = DiscordPerson(msg.author.id)
             err_msg.to = self.bot_identifier


### PR DESCRIPTION
Bots (most commonly webhooks) do not have a username.

This causes the on_message() function to fail when it is unable to match a userid to a username.

This patch ignores messages incoming from bots - this may not be ideal in all cases, but addresses my use case (messages being injected as webhooks via curl with no username)